### PR TITLE
Add versions for rioxarray and geopandas in pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,7 +9,7 @@ readme = "README.md"
 python = ">=3.11,<4"
 click = { git = "https://github.com/pallets/click.git" }
 requests = { git = "https://github.com/psf/requests.git" }
-geopandas = { git = "https://github.com/geopandas/geopandas.git" }
+geopandas = { git = "https://github.com/geopandas/geopandas.git", tag = "v1.1.2" }
 minio = { git = "https://github.com/minio/minio-py.git" }
 geopy = { git = "https://github.com/geopy/geopy.git" }
 rasterio = "1.4.3"
@@ -18,7 +18,7 @@ pystac-client = "0.8.6"
 networkx = { git = "https://github.com/networkx/networkx.git" }
 scipy = "1.15.2"
 tqdm = '4.67.0'
-rioxarray = {git = "https://github.com/corteva/rioxarray.git"}
+rioxarray = {git = "https://github.com/corteva/rioxarray.git", tag = "0.19.0"}
 scikit-image = '0.25.2'
 fiona ="1.10.1"
 numba = "0.61.2"


### PR DESCRIPTION
The PR allows for installation with pip like `pip install git+https://github.com/datakaveri/gdi-python-sdk`